### PR TITLE
Bump calico to v2.5.1

### DIFF
--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -4,7 +4,7 @@ set -eux
 rm -rf resource-build
 mkdir resource-build
 cd resource-build
-wget https://github.com/projectcalico/calicoctl/releases/download/v1.3.0/calicoctl
+wget https://github.com/projectcalico/calicoctl/releases/download/v1.5.0/calicoctl
 wget https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
 wget https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
 chmod +x calicoctl calico calico-ipam

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -26,7 +26,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v /var/log/calico:/var/log/calico \
   -v /opt/calicoctl:/opt/calicoctl \
-  quay.io/calico/node:v1.3.0
+  quay.io/calico/node:v2.5.1
 ExecStop=/usr/bin/docker rm -f calico-node
 Restart=always
 RestartSec=10

--- a/templates/calico-policy-controller.yaml
+++ b/templates/calico-policy-controller.yaml
@@ -19,7 +19,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          image: quay.io/calico/kube-policy-controller:v0.6.0
+          image: quay.io/calico/kube-policy-controller:v0.7.0
           env:
             - name: ETCD_ENDPOINTS
               value: {{ connection_string }}


### PR DESCRIPTION
This seems to fix https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/397. Early testing looks good.

We were previously on Calico v2.3. Check out this release note from [Calico v2.4](https://github.com/projectcalico/calico/releases/tag/v2.4.0):

> #105: Calico now implements the networking.k8s.io/NetworkPolicy API semantics as defined by Kubernetes when using the etcd datastore
> * Note: This represents a change in how existing Kubernetes NetworkPolicies are enforced by Calico. To maintain existing behavior when upgrading, follow these steps:
>   * In Namespaces that previously did not have the “DefaultDeny” annotation, you should delete any existing NetworkPolicy objects.
>   * In Namespaces that previously did have the “DefaultDeny” annotation, you can create the equivalent semantics by creating a NetworkPolicy that selects all pods but does not allow any traffic.