### PR TITLE
Fix hook failed: "stop"

### DIFF
--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -4,6 +4,7 @@ set -eux
 rm -rf resource-build
 mkdir resource-build
 cd resource-build
+# Please refer to layer-canal/versioning.md before changing any of these versions.
 wget https://github.com/projectcalico/calicoctl/releases/download/v1.5.0/calicoctl
 wget https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
 wget https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam

--- a/reactive/canal.py
+++ b/reactive/canal.py
@@ -44,7 +44,7 @@ def configure_cni(etcd, cni):
 
 
 @when('flannel.binaries.installed', 'calico.binaries.installed')
-@when_not('canal.version.set')
+@when_not('canal.version.set', 'canal.stopping')
 def set_canal_version():
     ''' Surface the currently deployed version of canal to Juju '''
     # Get flannel version
@@ -72,6 +72,11 @@ def ready():
         status_set('active', 'Flannel subnet ' + get_flannel_subnet())
     except FlannelSubnetNotFound:
         status_set('waiting', 'Waiting for Flannel')
+
+
+@hook('stop')
+def stop():
+    set_state('canal.stopping')
 
 
 def get_flannel_subnet():

--- a/reactive/canal.py
+++ b/reactive/canal.py
@@ -55,16 +55,8 @@ def set_canal_version():
         return
     flannel_version = output.split('v')[-1].strip()
 
-    # Get calico version
-    cmd = [os.path.join(CALICOCTL_PATH, 'calicoctl'), 'version']
-    output = check_output(cmd).decode('utf-8')
-    for line in output.splitlines():
-        if line.startswith('Version:'):
-            calico_version = line.split()[1].lstrip('v')
-            break
-    else:
-        hookenv.log('No version output from calicoctl, will retry')
-        return
+    # Please refer to layer-canal/versioning.md before changing this.
+    calico_version = '2.5.1'
 
     version = '%s/%s' % (flannel_version, calico_version)
     application_version_set(version)

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -27,6 +27,7 @@ ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
   -v /var/log/calico:/var/log/calico \
   -v /opt/calicoctl:/opt/calicoctl \
   quay.io/calico/node:v2.5.1
+# Please refer to layer-canal/versioning.md before changing the version above.
 ExecStop=/usr/bin/docker rm -f calico-node
 Restart=always
 RestartSec=10

--- a/templates/calico-policy-controller.yaml
+++ b/templates/calico-policy-controller.yaml
@@ -19,6 +19,7 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
+          # Please refer to layer-canal/versioning.md before changing this
           image: quay.io/calico/kube-policy-controller:v0.7.0
           env:
             - name: ETCD_ENDPOINTS

--- a/versioning.md
+++ b/versioning.md
@@ -1,0 +1,11 @@
+# layer-canal devs: How to bump Calico release versions
+
+TODO: fix this lousy process
+
+1. Check the component versions: https://docs.projectcalico.org/v2.5/releases/
+   (substitute v2.5 for latest version)
+2. Update calicoctl and calico-cni versions in build-calico-resource.sh
+3. Update calico-node version in templates/calico-node.service
+4. Update calico-policy-controller version in
+   templates/calico-policy-controller.yaml
+5. Update calico_version in reactive/canal.py set_canal_version function


### PR DESCRIPTION
This is primarily to fix https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/404.

I also fixed some versioning stuff here. The set_canal_version handler wasn't working because the output of `calicoctl version` has changed. More importantly, `calicoctl version` doesn't give us the version we want; that's the version of the calicoctl component, not the version of calico as a whole.

It sucks that the calico versions are spread out across so many files. Oh well.