### PR TITLE
stub out charm-pre-install to skip docker-compose setup to facilitate…

### DIFF
--- a/exec.d/docker-compose/charm-pre-install
+++ b/exec.d/docker-compose/charm-pre-install
@@ -1,0 +1,3 @@
+# This stubs out charm-pre-install coming from layer-docker as a workaround for 
+# offline installs until https://github.com/juju/charm-tools/issues/301 is fixed.
+


### PR DESCRIPTION
… offline installation

Probably fine to merge, but I'm still testing.