### PR TITLE
Add hairpin conf property to flannel

### DIFF
--- a/templates/10-canal.conflist
+++ b/templates/10-canal.conflist
@@ -5,6 +5,7 @@
       "type": "flannel",
       "delegate": {
         "type": "calico",
+        "hairpinMode": true,
         "etcd_endpoints": "{{ connection_string }}",
         "etcd_key_file": "{{ etcd_key_path }}",
         "etcd_cert_file": "{{ etcd_cert_path }}",


### PR DESCRIPTION
Haripinmode is needed for containers in the same pod to reach each other through cluster ip.