### PR TITLE
bump to recent 3.2.1 release

### DIFF
--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -5,10 +5,12 @@ rm -rf resource-build
 mkdir resource-build
 cd resource-build
 # Please refer to layer-canal/versioning.md before changing any of these versions.
-wget https://github.com/projectcalico/calicoctl/releases/download/v1.6.4/calicoctl
-wget https://github.com/projectcalico/cni-plugin/releases/download/v1.11.6/calico
-wget https://github.com/projectcalico/cni-plugin/releases/download/v1.11.6/calico-ipam
+wget https://github.com/projectcalico/calicoctl/releases/download/v3.2.1/calicoctl
+wget https://github.com/projectcalico/cni-plugin/releases/download/v3.2.1/calico
+wget https://github.com/projectcalico/cni-plugin/releases/download/v3.2.1/calico-ipam
+
 chmod +x calicoctl calico calico-ipam
+
 tar -vcaf ../calico-resource.tar.gz .
 cd ..
 rm -rf resource-build

--- a/config.yaml
+++ b/config.yaml
@@ -2,12 +2,12 @@ options:
   calico-node-image:
     type: string
     # Please refer to layer-canal/versioning.md before changing the version below.
-    default: quay.io/calico/node:v2.6.10
+    default: quay.io/calico/node:v3.2.1
     description: |
       The image id to use for calico/node.
   calico-policy-image:
     type: string
-    default: quay.io/calico/kube-controllers:v1.0.4
+    default: quay.io/calico/kube-controllers:v3.2.1
     description: |
       The image id to use for calico/kube-controllers.
   cidr:

--- a/reactive/canal.py
+++ b/reactive/canal.py
@@ -62,7 +62,7 @@ def set_canal_version():
     flannel_version = output.split('v')[-1].strip()
 
     # Please refer to layer-canal/versioning.md before changing this.
-    calico_version = '2.6.10'
+    calico_version = '3.2.1'
 
     version = '%s/%s' % (flannel_version, calico_version)
     application_version_set(version)

--- a/versioning.md
+++ b/versioning.md
@@ -2,10 +2,11 @@
 
 TODO: fix this lousy process
 
-1. Check the component versions: https://docs.projectcalico.org/v2.6/releases/
+1. Check the component versions: https://docs.projectcalico.org/v3.2/releases/
    (substitute v2.6 for latest version)
 2. Update calicoctl and calico-cni versions in build-calico-resource.sh
-3. Update calico-node version in templates/calico-node.service
-4. Update calico-policy-controller version in
-   templates/calico-policy-controller.yaml
+3. Update calico-node image in config.yaml
+   (used in templates/calico-node.service)
+4. Update calico-policy-controller image in config.yaml
+   (used in templates/calico-policy-controller.yaml)
 5. Update calico_version in reactive/canal.py set_canal_version function


### PR DESCRIPTION
Untested, but what could possibly go wrong with such a small change?

We need to go to 3.2.x for (easier) arm support, so I'd like to get this version in edge for testing sooner rather than later. (similar pr made for calico).