### PR TITLE
Fixing empty configuration due to timing issue with cni.

### DIFF
--- a/reactive/canal.py
+++ b/reactive/canal.py
@@ -39,9 +39,6 @@ def configure_cni():
     cni = endpoint_from_flag('cni.configured')
     etcd = endpoint_from_flag('etcd.available')
     cni_config = cni.get_config()
-    if 'kubeconfig_path' not in cni_config:
-        hookenv.log('Unable to get configuration for cni. Will retry.')
-        return
     context = {
         'connection_string': etcd.get_connection_string(),
         'etcd_key_path': ETCD_KEY_PATH,


### PR DESCRIPTION
The flag triggered on connected, but the configuration wasn't necessarily valid at that time. This uses the newly-created configured flag.

Note that this requires https://github.com/juju-solutions/interface-kubernetes-cni/pull/4