### PR TITLE
Fixing an issue where the calico-node service failed to start

### DIFF
--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -7,6 +7,7 @@ Requires=docker.service
 User=root
 Environment=ETCD_ENDPOINTS={{ connection_string }}
 PermissionsStartOnly=true
+ExecStartPre=-/usr/bin/docker rm -f calico-node
 ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
   -e ETCD_ENDPOINTS={{ connection_string }} \
   -e ETCD_CA_CERT_FILE={{ etcd_ca_path }} \


### PR DESCRIPTION
The container existed and this caused the service to fail to start.

Also surfacing service errors up to the user via juju status